### PR TITLE
Add drawing classifier integration

### DIFF
--- a/DRAWING_MODEL.md
+++ b/DRAWING_MODEL.md
@@ -1,0 +1,1 @@
+# Drawing Model\nThis app now loads a 4-class TFLite model for classifying drawings.

--- a/lib/services/drawing_predictor.dart
+++ b/lib/services/drawing_predictor.dart
@@ -1,48 +1,81 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'dart:ui' as ui;
 import 'package:image/image.dart' as img;
 import 'package:tflite_flutter/tflite_flutter.dart';
 
 class DrawingPredictor {
   late Interpreter _interpreter;
+  final List<String> _classNames = const [
+    'Healthy Spiral',
+    'Healthy Wave',
+    'Parkinson Spiral',
+    'Parkinson Wave'
+  ];
 
   Future<void> loadModel() async {
-    _interpreter = await Interpreter.fromAsset('models/keras_logistic_model.tflite');
+    _interpreter =
+        await Interpreter.fromAsset('assets/models/drawing_classifier.tflite');
   }
 
-  Future<String> predict(File imageFile) async {
+  Map<String, dynamic> _runModel(img.Image image) {
     const int inputSize = 128;
-    final classNames = [
-      'Healthy Spiral',
-      'Healthy Wave',
-      'Parkinson Spiral',
-      'Parkinson Wave'
-    ];
 
-    // Decode & preprocess
-    final bytes = await imageFile.readAsBytes();
-    img.Image? image = img.decodeImage(bytes);
-    if (image == null) throw Exception("Image could not be loaded.");
+    final img.Image resized =
+        img.copyResize(image, width: inputSize, height: inputSize);
+    final img.Image grayscale = img.grayscale(resized);
 
-    img.Image resized = img.copyResize(image, width: inputSize, height: inputSize);
-    img.Image grayscale = img.grayscale(resized);
-
-    // Normalize + flatten
-    List<double> inputList = grayscale
+    final List<double> inputList = grayscale
         .getBytes()
-        .map((e) => e / 255.0) // Normalize
+        .map((e) => e / 255.0)
         .toList()
         .cast<double>();
 
-    var input = Float32List.fromList(inputList).reshape([1, inputSize * inputSize]);
-    var output = List.filled(4, 0.0).reshape([1, 4]);
+    final input =
+        Float32List.fromList(inputList).reshape([1, inputSize * inputSize]);
+    final output = List.filled(4, 0.0).reshape([1, 4]);
 
     _interpreter.run(input, output);
 
     final prediction = output[0];
-    final predictedIndex = prediction.indexOf(prediction.reduce((a, b) => a > b ? a : b));
-    final confidence = prediction[predictedIndex];
+    int idx = 0;
+    double maxVal = prediction[0];
+    for (int i = 1; i < prediction.length; i++) {
+      if (prediction[i] > maxVal) {
+        maxVal = prediction[i];
+        idx = i;
+      }
+    }
 
-    return '${classNames[predictedIndex]} (Confidence: ${(confidence * 100).toStringAsFixed(2)}%)';
+    return {'index': idx, 'confidence': maxVal};
+  }
+
+  Future<Map<String, dynamic>> predictFile(File imageFile) async {
+    final bytes = await imageFile.readAsBytes();
+    final img.Image? image = img.decodeImage(bytes);
+    if (image == null) throw Exception('Image could not be loaded');
+    final result = _runModel(image);
+    return {
+      'label': _classNames[result['index'] as int],
+      'confidence': result['confidence'] as double,
+    };
+  }
+
+  Future<Map<String, dynamic>> predictCanvas(ui.Image canvasImage) async {
+    final byteData =
+        await canvasImage.toByteData(format: ui.ImageByteFormat.png);
+    if (byteData == null) throw Exception('Failed to convert image');
+    final img.Image? image =
+        img.decodeImage(byteData.buffer.asUint8List());
+    if (image == null) throw Exception('Image decode error');
+    final result = _runModel(image);
+    return {
+      'label': _classNames[result['index'] as int],
+      'confidence': result['confidence'] as double,
+    };
+  }
+
+  void dispose() {
+    _interpreter.close();
   }
 }

--- a/lib/ui/views/patience/patience_viewmodel.dart
+++ b/lib/ui/views/patience/patience_viewmodel.dart
@@ -14,6 +14,9 @@ import '../../../app/app.locator.dart';
 import '../../../services/authentication_service.dart';
 import '../../../services/test_service.dart';
 import '../../../services/reports_service.dart';
+import '../../../services/drawing_predictor.dart';
+import 'package:stacked_services/stacked_services.dart';
+import '../../../app/app.dialogs.dart';
 import '../../../models/test_result.dart';
 import '../../../models/patient_report.dart';
 import '../../../models/app_user.dart';
@@ -23,6 +26,8 @@ class PatienceViewModel extends BaseViewModel {
   final AuthenticationService _authService = locator<AuthenticationService>();
   final TestService _testService = locator<TestService>();
   final ReportsService _reportsService = locator<ReportsService>();
+  final DialogService _dialogService = locator<DialogService>();
+  final DrawingPredictor _drawingPredictor = DrawingPredictor();
 
   String get email => _authService.currentUser?.email ?? '--';
 
@@ -112,6 +117,8 @@ class PatienceViewModel extends BaseViewModel {
   // Initialization: Load user info, subscribe to result/report streams, preload doctors
   Future<void> init() async {
     setBusy(true);
+
+    await _drawingPredictor.loadModel();
 
     _name = await _authService.fetchDisplayName() ?? '--';
     nameController.text = _name == '--' ? '' : _name;
@@ -239,6 +246,20 @@ class PatienceViewModel extends BaseViewModel {
     await _testService.addResult(res);
   }
 
+  Future<void> _saveDrawingResult(double score, String label) async {
+    final uid = _authService.currentUser?.uid;
+    if (uid == null) return;
+    final result = TestResult(
+      id: '',
+      patientId: uid,
+      type: TestType.drawing,
+      performedAt: DateTime.now(),
+      score: score.clamp(0, 1),
+      data: {'label': label},
+    );
+    await _testService.addResult(result);
+  }
+
   /// Update the number of days used for the moving average
   void updateAverageWindow(int days) {
     // Ignore if the same value is selected
@@ -307,14 +328,35 @@ class PatienceViewModel extends BaseViewModel {
   // Stubs for the drawing test. When implemented these will run the ML model
   // on the provided input and save a [TestResult].
   Future<void> handleCanvasDrawing(ui.Image img) async {
-    // TODO: run model
+    final result = await _drawingPredictor.predictCanvas(img);
+    await _saveDrawingResult(result['confidence'] as double, result['label'] as String);
+    _dialogService.showCustomDialog(
+      variant: DialogType.infoAlert,
+      title: 'Drawing Result',
+      description:
+          '${result['label']}\nConfidence: ${(result['confidence'] as double * 100).toStringAsFixed(1)}%',
+    );
   }
 
   Future<void> handleCameraImage(File file) async {
-    // TODO
+    final result = await _drawingPredictor.predictFile(file);
+    await _saveDrawingResult(result['confidence'] as double, result['label'] as String);
+    _dialogService.showCustomDialog(
+      variant: DialogType.infoAlert,
+      title: 'Drawing Result',
+      description:
+          '${result['label']}\nConfidence: ${(result['confidence'] as double * 100).toStringAsFixed(1)}%',
+    );
   }
 
   Future<void> handleGalleryImage(File file) async {
-    // TODO
+    final result = await _drawingPredictor.predictFile(file);
+    await _saveDrawingResult(result['confidence'] as double, result['label'] as String);
+    _dialogService.showCustomDialog(
+      variant: DialogType.infoAlert,
+      title: 'Drawing Result',
+      description:
+          '${result['label']}\nConfidence: ${(result['confidence'] as double * 100).toStringAsFixed(1)}%',
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   shared_preferences: ^2.2.2
   signature: ^6.1.0
   image_picker: ^1.0.4
+  image: ^4.5.4
 
 dev_dependencies:
   build_runner: ^2.4.5


### PR DESCRIPTION
## Summary
- add `image` dependency for preprocessing
- implement `DrawingPredictor` with new 4-class tflite model
- hook drawing prediction into `PatienceViewModel` and show results via dialog
- document drawing model usage

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec80117fc8327a294a59b0b28815d